### PR TITLE
Consolidate with base-orphans package

### DIFF
--- a/out-of-base/Foreign/Storable/Complex.hs
+++ b/out-of-base/Foreign/Storable/Complex.hs
@@ -15,23 +15,6 @@
 --
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Foreign.Storable.Complex () where
 
-import Data.Complex
-import Foreign.Storable
-import Foreign.Ptr
-
--- This Storable instance for Complex is binary compatible with C99, C++ and
--- Fortran complex data types.
-instance Storable a => Storable (Complex a) where
-    sizeOf z        = 2 * sizeOf (undefined :: a)
-    alignment z     = alignment (undefined :: a)
-    peek p          = do let q = castPtr p
-                         r <- peek q
-                         i <- peekElemOff q 1
-                         return (r :+ i)
-    poke p (r :+ i) = do let q = (castPtr p)
-                         poke q r
-                         pokeElemOff q 1 i
+import Data.Orphans () -- exports a Storable (Complex a) instance

--- a/storable-complex.cabal
+++ b/storable-complex.cabal
@@ -36,5 +36,5 @@ library
     hs-source-dirs: in-base
   else
     build-depends:  base  < 4.8 && >= 4.4,
-                    base-orphans >= 0.3.2 && < 1
+                    base-orphans >= 0.5.1 && < 1
     hs-source-dirs: out-of-base

--- a/storable-complex.cabal
+++ b/storable-complex.cabal
@@ -35,5 +35,6 @@ library
     build-depends:  base >= 4.8 && < 5
     hs-source-dirs: in-base
   else
-    build-depends:  base  < 4.8 && >= 4.4
+    build-depends:  base  < 4.8 && >= 4.4,
+                    base-orphans >= 0.3.2 && < 1
     hs-source-dirs: out-of-base


### PR DESCRIPTION
Currently, both `base-orphans` and `storable-complex` export a `Storable (Complex a)` instance, which could cause conflicts if anyone decides to use both libraries in a project using GHC 7.8 or earlier. My goal with `base-orphans` is to provide a common source for all orphan instances introduced by changes to `base`, so I think it makes to sense to define the `Storable (Complex a)` orphan instance there.

This change simply re-exports the instance from `base-orphans` so that projects depending on `storable-complex` will continue to work while also being compatible with other libraries that depend on `base-orphans`.

(We did something similar with the [`errorcall-eq-instance`](http://hackage.haskell.org/package/errorcall-eq-instance) package a while back.)
