### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/storable-complex.cabal
+++ b/storable-complex.cabal
@@ -15,7 +15,7 @@ maintainer:          Carter Schonwald <carter.schonwald@gmail.com>
 homepage:      https://github.com/cartazio/storable-complex
 bug-reports:   https://github.com/cartazio/storable-complex/issues
 build-type:      Simple
-cabal-version:       >= 1.6
+cabal-version:       >= 1.8
 extra-source-files:
   .travis.yml
   README.md


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: storable-complex.cabal:31:31: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```